### PR TITLE
Add a synonym to be able to invoke an app action correctly (codelab-start-beta)

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -18,6 +18,7 @@
 <resources>
     <array name="completed_tasks_synonyms">
         <item>completed</item>
+        <item>completed tasks</item>
         <item>finished</item>
         <item>finished tasks</item>
     </array>


### PR DESCRIPTION
[In the bottom of the page 5](https://codelabs.developers.google.com/codelabs/appactions-beta?hl=en&continue=https%3A%2F%2Fcodelabs.developers.google.com%2F#4), there is the invocation phrase to open the completed tasks page:

> For example, you could say "Hey Google, show completed tasks in Task List".

Actually, the invocation phrase is wrong and we can't open the completed task list. Instead, the invocation will be recognized as the GET_THING invocation. Because, the "completed task" phrase is not included in the synonym list defined in the arrays.xml file.

This pull request adds a new synonym to be able to invoke an app action correctly with the phrase above.