### PR TITLE
Google Play Store only accepts targetSdkVersion 30+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,8 +57,8 @@ ext {
     // Sdk and tools
     // App Actions supported on minSdk 21 and above.
     minSdkVersion = 21
-    targetSdkVersion = 29
-    compileSdkVersion = 28
+    targetSdkVersion = 30
+    compileSdkVersion = 30
 
     // App dependencies
     androidXVersion = '1.0.0'


### PR DESCRIPTION
Google Play Store only accepts targetSdkVersion 30+;
And as uploading the App to the Google Play Store is required for the code lab, this is important.